### PR TITLE
Remove trailing / in publiccode.yml URL

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,6 +1,6 @@
 publiccodeYmlVersion: "0.4"
 name: Open Source Guidelines
-url: https://github.com/swiss/opensource-guidelines/
+url: https://github.com/swiss/opensource-guidelines
 landingURL: https://www.bk.admin.ch/bk/de/home/digitale-transformation-ikt-lenkung/bundesarchitektur/open_source_software/hilfsmittel_oss.html
 softwareVersion: "1.0"
 releaseDate: 2024-10-02


### PR DESCRIPTION
According to the https://github.com/italia/publiccode-crawler the publiccode.yml in this repository is not valid. I suppose this is due to a trailing / in the `url` value.